### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/src/org/jaudiotagger/audio/generic/AudioFileWriter.java
+++ b/src/org/jaudiotagger/audio/generic/AudioFileWriter.java
@@ -103,7 +103,7 @@ public abstract class AudioFileWriter
         try
         {
 
-            tempF = File.createTempFile(af.getFile().getName().replace('.', '_'), TEMP_FILENAME_SUFFIX, af.getFile().getParentFile());
+            tempF = Files.createTempFile(af.getFile().getParentFile().toPath(),af.getFile().getName().replace('.','_'),TEMP_FILENAME_SUFFIX).toFile();
             rafTemp = new RandomAccessFile(tempF, WRITE_MODE);
             raf = new RandomAccessFile(af.getFile(), WRITE_MODE);
             raf.seek(0);
@@ -314,7 +314,7 @@ public abstract class AudioFileWriter
         // Create temporary File
         try
         {
-            newFile = File.createTempFile(af.getFile().getName().replace('.', '_'), TEMP_FILENAME_SUFFIX, af.getFile().getParentFile());
+            newFile = Files.createTempFile(af.getFile().getParentFile().toPath(),af.getFile().getName().replace('.','_'),TEMP_FILENAME_SUFFIX).toFile();
         }
         // Unable to create temporary file, can happen in Vista if have Create
         // Files/Write Data set to Deny
@@ -325,7 +325,7 @@ public abstract class AudioFileWriter
                 try
                 {
 
-                    newFile = File.createTempFile(af.getFile().getName().substring(0, FILE_NAME_TOO_LONG_SAFE_LIMIT).replace('.', '_'), TEMP_FILENAME_SUFFIX, af.getFile().getParentFile());
+                    newFile = Files.createTempFile(af.getFile().getParentFile().toPath(),af.getFile().getName().substring(0,FILE_NAME_TOO_LONG_SAFE_LIMIT).replace('.','_'),TEMP_FILENAME_SUFFIX).toFile();
 
                 }
                 catch (IOException ioe2)

--- a/src/org/jaudiotagger/tag/id3/AbstractID3v2Tag.java
+++ b/src/org/jaudiotagger/tag/id3/AbstractID3v2Tag.java
@@ -42,6 +42,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.logging.Level;
 
@@ -1317,7 +1318,7 @@ public abstract class AbstractID3v2Tag extends AbstractID3Tag implements Tag
 
         try
         {
-            paddedFile = File.createTempFile(Utils.getBaseFilenameForTempFile(file), ".new", file.getParentFile());
+            paddedFile = Files.createTempFile(file.getParentFile().toPath(),Utils.getBaseFilenameForTempFile(file),".new").toFile();
             logger.finest("Created temp file:" + paddedFile.getName() + " for " + file.getName());
         }
         //Vista:Can occur if have Write permission on folder this file would be created in Denied

--- a/srctest/org/jaudiotagger/audio/aiff/AiffFileHeaderTest.java
+++ b/srctest/org/jaudiotagger/audio/aiff/AiffFileHeaderTest.java
@@ -6,6 +6,7 @@ import org.jaudiotagger.audio.exceptions.CannotReadException;
 import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Random;
 
 import static org.jaudiotagger.audio.aiff.AiffType.AIFC;
@@ -90,7 +91,7 @@ public class AiffFileHeaderTest extends TestCase {
     }
 
     private static File createAIFF(final String form, final String formType, final int size) throws IOException {
-        final File tempFile = File.createTempFile(AiffFileHeaderTest.class.getSimpleName(), ".aif");
+        final File tempFile = Files.createTempFile(AiffFileHeaderTest.class.getSimpleName(),".aif").toFile();
         tempFile.deleteOnExit();
 
         try (final DataOutputStream out = new DataOutputStream(new FileOutputStream(tempFile))) {

--- a/srctest/org/jaudiotagger/audio/aiff/AiffInfoReaderTest.java
+++ b/srctest/org/jaudiotagger/audio/aiff/AiffInfoReaderTest.java
@@ -7,6 +7,7 @@ import org.jaudiotagger.audio.generic.GenericAudioHeader;
 import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  * AiffInfoReader Test.
@@ -78,7 +79,7 @@ public class AiffInfoReaderTest extends TestCase {
     }
 
     private static File createAIFF(final String form, final String formType, final PseudoChunk... chunks) throws IOException {
-        final File tempFile = File.createTempFile(AiffFileHeaderTest.class.getSimpleName(), ".aif");
+        final File tempFile = Files.createTempFile(AiffFileHeaderTest.class.getSimpleName(),".aif").toFile();
         tempFile.deleteOnExit();
 
         try (final DataOutputStream out = new DataOutputStream(new FileOutputStream(tempFile))) {

--- a/srctest/org/jaudiotagger/audio/generic/AudioFileWriterTest.java
+++ b/srctest/org/jaudiotagger/audio/generic/AudioFileWriterTest.java
@@ -29,7 +29,7 @@ public class AudioFileWriterTest extends TestCase {
 
     @Override
     protected void setUp() throws IOException {
-        final File file = File.createTempFile("AudioFileWriterTest", ".bin");
+        final File file = Files.createTempFile("AudioFileWriterTest",".bin").toFile();
         try (final FileOutputStream out = new FileOutputStream(file)) {
             for (int i=0; i<100; i++) out.write("Some random stuff\n".getBytes(StandardCharsets.US_ASCII));
         }


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
